### PR TITLE
Read stats.json from new build artifacts folder in dev

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,14 +37,28 @@ function resolveChunkSelector(options) {
 }
 
 /**
- * Load stats.json which is created during build.
- * The file contains bundle files which are to be loaded on the client side.
+ * Attempt to load the stats.json file which contains a manifest of
+ * the assets outputted by webpack. If the file does not exist, we check
+ * if the WEBPACK_DEV environmental varibale is "true". If it is, we assume
+ * we're running this server via webpack-dev-sever. Otherwise, we throw an
+ * error since we assume we're attempting to run a production build.
  *
  * @param {string} statsFilePath - path of stats.json
+ * @param {string} buildArtifactsPath - path of directory used for build artifacts
  * @returns {Promise.<Object>} an object containing an array of file names
  */
-function loadAssetsFromStats(statsFilePath) {
-  return Promise.resolve(Path.resolve(statsFilePath))
+function loadAssetsFromStats(statsFilePath, buildArtifactsPath) {
+  let statsPath = Path.resolve(statsFilePath);
+  try {
+    fs.statSync(statsPath);
+  } catch (err) {
+    if (process.env.WEBPACK_DEV === "true") {
+      statsPath = Path.resolve(process.cwd(), buildArtifactsPath, "stats.json");
+    } else {
+      throw new Error(`Unable to load stats.json from ${statsFilePath}`);
+    }
+  }
+  return Promise.resolve(Path.resolve(statsPath))
     .then(require)
     .then((stats) => {
       const assets = {};
@@ -64,7 +78,6 @@ function loadAssetsFromStats(statsFilePath) {
 
       assets.js = jsAssets;
       assets.css = cssAssets;
-
       return assets;
     })
     .catch(() => ({}));
@@ -120,11 +133,11 @@ function makeRouteHandler(options, userContent) {
       `${devBundleBase}bundle.dev.js`;
     const jsChunk = _.find(
       assets.js,
-      (asset) => asset.chunkNames[0] === (chunkNames.js || "bundle")
+      (asset) => asset.chunkNames[0] === (chunkNames.js)
     );
     const cssChunk = _.find(
       assets.css,
-      (asset) => asset.chunkNames[0] === (chunkNames.css || "bundle")
+      (asset) => asset.chunkNames.includes(chunkNames.css)
     );
 
     const bundleCss = () => {
@@ -241,7 +254,8 @@ const registerRoutes = (server, options, next) => {
     paths: {},
     stats: "dist/server/stats.json",
     iconStats: "dist/server/iconstats.json",
-    criticalCSS: "dist/js/critical.css"
+    criticalCSS: "dist/js/critical.css",
+    buildArtifacts: ".build"
   };
 
   const resolveContent = (content) => {
@@ -257,7 +271,7 @@ const registerRoutes = (server, options, next) => {
   const chunkSelector = resolveChunkSelector(pluginOptions);
   const devBundleBase = `http://${pluginOptions.devServer.host}:${pluginOptions.devServer.port}/js/`;
 
-  return Promise.try(() => loadAssetsFromStats(pluginOptions.stats))
+  return Promise.try(() => loadAssetsFromStats(pluginOptions.stats, pluginOptions.buildArtifacts))
     .then((assets) => {
       pluginOptions.__internals = {
         assets,

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,27 +37,14 @@ function resolveChunkSelector(options) {
 }
 
 /**
+ * Load stats.json which is created during build.
  * Attempt to load the stats.json file which contains a manifest of
- * the assets outputted by webpack. If the file does not exist, we check
- * if the WEBPACK_DEV environmental varibale is "true". If it is, we assume
- * we're running this server via webpack-dev-sever. Otherwise, we throw an
- * error since we assume we're attempting to run a production build.
+ * The file contains bundle files which are to be loaded on the client side.
  *
- * @param {string} statsFilePath - path of stats.json
- * @param {string} buildArtifactsPath - path of directory used for build artifacts
+ * @param {string} statsPath - path of stats.json
  * @returns {Promise.<Object>} an object containing an array of file names
  */
-function loadAssetsFromStats(statsFilePath, buildArtifactsPath) {
-  let statsPath = Path.resolve(statsFilePath);
-  try {
-    fs.statSync(statsPath);
-  } catch (err) {
-    if (process.env.WEBPACK_DEV === "true") {
-      statsPath = Path.resolve(process.cwd(), buildArtifactsPath, "stats.json");
-    } else {
-      throw new Error(`Unable to load stats.json from ${statsFilePath}`);
-    }
-  }
+function loadAssetsFromStats(statsPath) {
   return Promise.resolve(Path.resolve(statsPath))
     .then(require)
     .then((stats) => {
@@ -105,6 +92,21 @@ function getCriticalCSS(path) {
   } catch (err) {
     return "";
   }
+}
+
+/**
+ * Resolves the path to the stats.json file containing our
+ * asset list. In dev the stats.json file is written to a
+ * build artifacts directory, while in produciton its contained
+ * within the dist/server folder
+ * @param  {string} statsFilePath      path to stats.json
+ * @param  {string} buildArtifactsPath path to stats.json in dev
+ * @return {string}                    current active path
+ */
+function getStatsPath(statsFilePath, buildArtifactsPath) {
+  return process.env.WEBPACK_DEV === "true"
+    ? Path.resolve(process.cwd(), buildArtifactsPath, "stats.json")
+    : statsFilePath;
 }
 
 function makeRouteHandler(options, userContent) {
@@ -270,8 +272,9 @@ const registerRoutes = (server, options, next) => {
   const pluginOptions = _.defaultsDeep({}, options, pluginOptionsDefaults);
   const chunkSelector = resolveChunkSelector(pluginOptions);
   const devBundleBase = `http://${pluginOptions.devServer.host}:${pluginOptions.devServer.port}/js/`;
+  const statsPath = getStatsPath(pluginOptions.stats, pluginOptions.buildArtifacts);
 
-  return Promise.try(() => loadAssetsFromStats(pluginOptions.stats, pluginOptions.buildArtifacts))
+  return Promise.try(() => loadAssetsFromStats(statsPath))
     .then((assets) => {
       pluginOptions.__internals = {
         assets,

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,7 @@ function makeRouteHandler(options, userContent) {
       `${devBundleBase}bundle.dev.js`;
     const jsChunk = _.find(
       assets.js,
-      (asset) => asset.chunkNames[0] === (chunkNames.js)
+      (asset) => _.includes(asset.chunkNames, chunkNames.js)
     );
     const cssChunk = _.find(
       assets.css,

--- a/lib/index.js
+++ b/lib/index.js
@@ -139,7 +139,7 @@ function makeRouteHandler(options, userContent) {
     );
     const cssChunk = _.find(
       assets.css,
-      (asset) => asset.chunkNames.includes(chunkNames.css)
+      (asset) => _.includes(asset.chunkNames, chunkNames.css)
     );
 
     const bundleCss = () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,8 +31,8 @@ function resolveChunkSelector(options) {
   }
 
   return () => ({
-    css: "",
-    js: ""
+    css: "main",
+    js: "main"
   });
 }
 

--- a/test/data/chunk-selector.js
+++ b/test/data/chunk-selector.js
@@ -9,8 +9,8 @@ const BAR_BUNDLE = {
   js: "bar"
 };
 const DEFAULT_BUNDLE = {
-  css: "",
-  js: ""
+  css: "home",
+  js: "home"
 };
 
 module.exports = (request) => {

--- a/test/data/stats-test-multibundle.json
+++ b/test/data/stats-test-multibundle.json
@@ -7,6 +7,10 @@
     "bar": [
       "bar.bundle.f07a873ce87fc904a6a5.js",
       "bar.style.f07a873ce87fc904a6a5.css"
+    ],
+    "home": [
+      "home.bundle.f07a873ce87fc904a6a5.js",
+      "home.style.f07a873ce87fc904a6a5.css"
     ]
   },
   "assets": [{
@@ -46,22 +50,22 @@
       "bar"
     ]
   }, {
-     "name": "style.f07a873ce87fc904a6a5.css",
+     "name": "home.style.f07a873ce87fc904a6a5.css",
       "size": 888,
       "chunks": [
         0
       ],
       "chunkNames": [
-        "bundle"
+        "home"
       ]
   }, {
-    "name": "bundle.f07a873ce87fc904a6a5.js",
+    "name": "home.bundle.f07a873ce87fc904a6a5.js",
     "size": 888,
     "chunks": [
       0
     ],
     "chunkNames": [
-      "bundle"
+      "home"
     ]
   }]
 }


### PR DESCRIPTION
We need `stats.json` to know which chunks to consume, and in dev the file is not written to disk thanks to `webpack-dev-server`'s memory only policy.

This relies on some changes to the archetype (incoming PR) that now writes the stats file to a build artifacts directory, which defaults to `.build`.

This also changes the default chunk selector to `main` instead of an empty string. This is due to upcoming changes in the archetype where `output.filename` no longer switches on `wmlMultiBundle`. We always just use `[name].bundle.dev.js`. This reduces the complexity of handling single and multiple entry points, since Webpack will use a default chunk name of `"main"` for single entry points.

cc @ananavati @jmcriffey @donsalari 